### PR TITLE
fix: add try catch to apicall in src/pages/bar/index.tsx

### DIFF
--- a/src/pages/bar/index.tsx
+++ b/src/pages/bar/index.tsx
@@ -155,9 +155,11 @@ export default function Stake() {
   // TODO: DROP AND USE SWR HOOKS INSTEAD
   useEffect(() => {
     const fetchData = async () => {
-      const results = await getDayData()
-      const apr = (((results[1].volumeUSD * 0.05) / data?.bar?.totalSupply) * 365) / (data?.bar?.ratio * tangoPrice)
-      setApr(apr)
+      const results = await getDayData().catch(console.error)
+      if (results) {
+        const apr = (((results[1].volumeUSD * 0.05) / data?.bar?.totalSupply) * 365) / (data?.bar?.ratio * tangoPrice)
+        setApr(apr)
+      }
     }
     fetchData()
   }, [data?.bar?.ratio, data?.bar?.totalSupply, tangoPrice])


### PR DESCRIPTION
I added a try catch to the apicall of `bar` page, that is the same as `stake` page.

If you wanna handle custom logic of the failing flow, just modify the function parameter passed to `catch` on line 158. And maybe you wanna consider adding a message on the UI in case results is `undefined`.