### PR TITLE
fix: word break in NavLink components

### DIFF
--- a/src/components/NavLink/index.tsx
+++ b/src/components/NavLink/index.tsx
@@ -18,12 +18,11 @@ const NavLink = ({ children, exact = false, activeClassName = 'text-high-emphesi
 
   const className = isActive ? `${childClassName} ${activeClassName}`.trim() : childClassName
 
-  // console.log({ asPath, pathname, route, query })
-
   return (
     <Link href={props.href} {...props}>
       {React.cloneElement(child, {
         className: className || null,
+        style: { wordBreak: 'break-word' },
       })}
     </Link>
   )

--- a/src/features/trade/Header.tsx
+++ b/src/features/trade/Header.tsx
@@ -25,8 +25,8 @@ interface ExchangeHeaderProps {
   input?: Currency
   output?: Currency
   allowedSlippage?: Percent
-  refreshPrice?: () => void;
-  refreshingPrice?: boolean;
+  refreshPrice?: () => void
+  refreshingPrice?: boolean
 }
 
 const ExchangeHeader: FC<ExchangeHeaderProps> = ({ input, output, allowedSlippage, refreshPrice, refreshingPrice }) => {
@@ -38,15 +38,28 @@ const ExchangeHeader: FC<ExchangeHeaderProps> = ({ input, output, allowedSlippag
   const isLimitOrder = router.asPath.startsWith('/limit-order')
 
   useEffect(() => {
-    const interval = setInterval(refreshPrice, 10000);
-    return () => clearInterval(interval);
-  }, [refreshPrice]);
+    const interval = setInterval(refreshPrice, 10000)
+    return () => clearInterval(interval)
+  }, [refreshPrice])
+
+  const linkStyles = [
+    'font-bold border',
+    'rounded',
+    'text-high-emphesis',
+    'border-dark-800',
+    'bg-gradient-to-r',
+    'from-opaque-blue',
+    'to-opaque-pink',
+    'hover:from-blue',
+    'hover:to-pink',
+    'text-break',
+  ].join(' ')
 
   return (
     <div className="flex items-center justify-between mb-4 space-x-3">
-      <div className="grid grid-cols-3 rounded p-3px bg-dark-800 h-[46px]">
+      <div className="grid grid-cols-3 rounded p-3px bg-dark-800 min-h-[46px]">
         <NavLink
-          activeClassName="font-bold border rounded text-high-emphesis border-dark-800 bg-gradient-to-r from-opaque-blue to-opaque-pink hover:from-blue hover:to-pink"
+          activeClassName={linkStyles}
           href={{
             pathname: '/swap',
             query: getQuery(input, output),
@@ -57,7 +70,7 @@ const ExchangeHeader: FC<ExchangeHeaderProps> = ({ input, output, allowedSlippag
           </a>
         </NavLink>
         <NavLink
-          activeClassName="font-bold border rounded text-high-emphesis border-dark-800 bg-gradient-to-r from-opaque-blue to-opaque-pink hover:from-blue hover:to-pink"
+          activeClassName={linkStyles}
           href={{
             pathname: '/smart-swap',
             query: getQuery(input, output),
@@ -68,7 +81,7 @@ const ExchangeHeader: FC<ExchangeHeaderProps> = ({ input, output, allowedSlippag
           </a>
         </NavLink>
         <NavLink
-          activeClassName="font-bold border rounded text-high-emphesis border-dark-800 bg-gradient-to-r from-opaque-blue to-opaque-pink hover:from-blue hover:to-pink"
+          activeClassName={linkStyles}
           href={`/${!isRemove ? 'add' : 'remove'}${input ? `/${currencyId(input)}` : ''}${
             output ? `/${currencyId(output)}` : ''
           }`}
@@ -99,13 +112,16 @@ const ExchangeHeader: FC<ExchangeHeaderProps> = ({ input, output, allowedSlippag
               </div>
             </div>
           )*/}
-          {refreshPrice &&
-            <div onClick={refreshPrice} className="relative flex items-center justify-center rounded hover:bg-dark-800 w-8 h-8 rounded cursor-pointer">
-              <span className={refreshingPrice ? "animate-spin opacity-40" : undefined}>
+          {refreshPrice && (
+            <div
+              onClick={refreshPrice}
+              className="relative flex items-center justify-center rounded hover:bg-dark-800 w-8 h-8 rounded cursor-pointer"
+            >
+              <span className={refreshingPrice ? 'animate-spin opacity-40' : undefined}>
                 <RefreshIcon className="w-[26px] h-[26px] transform" />
               </span>
             </div>
-          }
+          )}
           <div className="relative flex items-center w-full h-full rounded hover:bg-dark-800">
             <Settings placeholderSlippage={allowedSlippage} />
           </div>


### PR DESCRIPTION
If you go to mobile, the NavLink text overflow the node container. It is more explicit on some languages in particular. For example, in Spanish, "Intercambio" text overlaps "SmartSwap".

In order to fix the overflow I set word-break css attribute. And in order to fix the height (we should allow the text goes in more than one line), I change it to min-height.
