### PR TITLE
fix: buttons should have focus ring because of a11y

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -48,10 +48,6 @@ a {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
-button:focus {
-  outline: none;
-}
-
 input:focus {
   box-shadow: none;
   outline: none;


### PR DESCRIPTION
Buttons should have focus ring because of a11y.

This default behavior helps people with disabilities to navigate the page using keyboard.