### PR TITLE
fix: a11y in refresh price button

### DIFF
--- a/src/features/trade/Header.tsx
+++ b/src/features/trade/Header.tsx
@@ -99,13 +99,16 @@ const ExchangeHeader: FC<ExchangeHeaderProps> = ({ input, output, allowedSlippag
               </div>
             </div>
           )*/}
-          {refreshPrice &&
-            <div onClick={refreshPrice} className="relative flex items-center justify-center rounded hover:bg-dark-800 w-8 h-8 rounded cursor-pointer">
-              <span className={refreshingPrice ? "animate-spin opacity-40" : undefined}>
-                <RefreshIcon className="w-[26px] h-[26px] transform" />
+          {refreshPrice && (
+            <button
+              onClick={refreshPrice}
+              className="relative flex items-center justify-center rounded hover:bg-dark-800 w-8 h-8 rounded cursor-pointer"
+            >
+              <span className={refreshingPrice ? 'animate-spin opacity-40' : undefined}>
+                <RefreshIcon aria-hidden className="w-[26px] h-[26px] transform" />
               </span>
-            </div>
-          }
+            </button>
+          )}
           <div className="relative flex items-center w-full h-full rounded hover:bg-dark-800">
             <Settings placeholderSlippage={allowedSlippage} />
           </div>

--- a/src/features/trade/HeaderSmart.tsx
+++ b/src/features/trade/HeaderSmart.tsx
@@ -100,13 +100,16 @@ const ExchangeHeader: FC<ExchangeHeaderProps> = ({ input, output, allowedSlippag
               </div>
             </div>
           )*/}
-          {refreshPrice &&
-            <div onClick={refreshPrice} className="relative flex items-center justify-center rounded hover:bg-dark-800 w-8 h-8 rounded cursor-pointer">
-              <span className={refreshingPrice ? "animate-spin opacity-40" : undefined}>
-                <RefreshIcon className="w-[26px] h-[26px] transform" />
+          {refreshPrice && (
+            <button
+              onClick={refreshPrice}
+              className="relative flex items-center justify-center rounded hover:bg-dark-800 w-8 h-8 rounded cursor-pointer"
+            >
+              <span className={refreshingPrice ? 'animate-spin opacity-40' : undefined}>
+                <RefreshIcon aria-hidden className="w-[26px] h-[26px] transform" />
               </span>
-            </div>
-          }
+            </button>
+          )}
           <div className="relative flex items-center w-full h-full rounded hover:bg-dark-800">
             <Settings placeholderSlippage={allowedSlippage} />
           </div>


### PR DESCRIPTION
- Refresh price button now is a button.
- The SVG child now has aria-hidden="true" attribute.
- The next step consist in adding an aria-label to the button with an expressive text (such as "Refresh price") and manage the translations.